### PR TITLE
Feature eliminate years divisible by 4000

### DIFF
--- a/src/leapyear/LeapYear.java
+++ b/src/leapyear/LeapYear.java
@@ -16,7 +16,7 @@ public class LeapYear {
         boolean valid = false;
         if(year%4 == 0){
             valid = true;
-            if(year%100 == 0 && year%400 != 0){
+            if((year%100 == 0 && year%400 != 0) || year%4000 ==0){
                 valid = false;
             }
         }

--- a/src/leapyear/LeapYear.java
+++ b/src/leapyear/LeapYear.java
@@ -14,6 +14,12 @@ public class LeapYear {
      */
     boolean isLeapYear(int year){
         boolean valid = false;
+        if(year%4 == 0){
+            valid = true;
+            if(year%100 == 0 && year%400 != 0){
+                valid = false;
+            }
+        }
         return valid;
     }
     /**

--- a/test/leapyear/LeapYearTest.java
+++ b/test/leapyear/LeapYearTest.java
@@ -1,13 +1,7 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package leapyear;
 
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
-
 
 /**
  *
@@ -34,7 +28,7 @@ public class LeapYearTest {
      */
     @Test
     public void testWithYearsDivisibleBy100ButNotBy400(){
-        int year = 2000;
+        int year = 1900;
         boolean expResult = false;
         boolean result = instance.isLeapYear(year);
         assertEquals(expResult, result);
@@ -46,7 +40,7 @@ public class LeapYearTest {
      */
     @Test
     public void testWithYearsDivisibleBy4ButNotBy100() {
-        int year = 2008;
+        int year = 2016;
         boolean expResult = true;
         boolean result = instance.isLeapYear(year);
         assertEquals(expResult, result);
@@ -58,7 +52,7 @@ public class LeapYearTest {
      */
     @Test
     public void testWithYearsNotDivisibleBy() {
-        int year = 2017;
+        int year = 2019;
         boolean expResult = false;
         boolean result = instance.isLeapYear(year);
         assertEquals(expResult, result);

--- a/test/leapyear/LeapYearTest.java
+++ b/test/leapyear/LeapYearTest.java
@@ -1,3 +1,15 @@
+/***************************************************
+ *              LEAP YEARS
+ * This short and simple Kata should be performed in 
+ * pairs using Test Driven Development (TDD).
+ *              
+ *              ACCEPTANCE CRITERIA
+ * All years divisible by 400 ARE leap years (so, for example, 2000 was indeed a leap year),
+ * All years divisible by 100 but not by 400 are NOT leap years 
+ * (so, for example, 1700, 1800, and 1900 were NOT leap years, NOR will 2100 be a leap year),
+ * All years divisible by 4 but not by 100 ARE leap years (e.g., 2008, 2012, 2016),
+ * All years not divisible by 4 are NOT leap years (e.g. 2017, 2018, 2019).
+ */
 package leapyear;
 
 import static org.junit.Assert.assertEquals;

--- a/test/leapyear/LeapYearTest.java
+++ b/test/leapyear/LeapYearTest.java
@@ -69,4 +69,16 @@ public class LeapYearTest {
         boolean result = instance.isLeapYear(year);
         assertEquals(expResult, result);
     }
+    
+    /**
+     * Test of years divisible by 4000 are NOT leap years 
+     * e.g. 4000, 8000, 12000.
+     */
+    @Test
+    public void testWithYearsDivisibleBy4000() {
+        int year = 4000;
+        boolean expResult = false;
+        boolean result = instance.isLeapYear(year);
+        assertEquals(expResult, result);
+    }
 }

--- a/test/leapyear/LeapYearTest.java
+++ b/test/leapyear/LeapYearTest.java
@@ -63,7 +63,7 @@ public class LeapYearTest {
      * e.g. 2017, 2018, 2019.
      */
     @Test
-    public void testWithYearsNotDivisibleBy() {
+    public void testWithYearsNotDivisibleBy4() {
         int year = 2019;
         boolean expResult = false;
         boolean result = instance.isLeapYear(year);

--- a/test/leapyear/LeapYearTest.java
+++ b/test/leapyear/LeapYearTest.java
@@ -76,7 +76,7 @@ public class LeapYearTest {
      */
     @Test
     public void testWithYearsDivisibleBy4000() {
-        int year = 4000;
+        int year = 12000;
         boolean expResult = false;
         boolean result = instance.isLeapYear(year);
         assertEquals(expResult, result);


### PR DESCRIPTION
This feature creates an additional rule that eliminates years divisible by 4000 as leap years.